### PR TITLE
fix: 修复循环依赖和重试逻辑问题

### DIFF
--- a/controller/relay.go
+++ b/controller/relay.go
@@ -2655,7 +2655,12 @@ func RelayResponse(c *gin.Context) {
 	// 处理首次失败的渠道错误（包括自动禁用逻辑）
 	go processChannelRelayError(ctx, userId, originalChannelId, originalChannelName, originalKeyIndex, relayError, originalModel)
 
-	lastFailedChannelId := channelId
+	// 记录所有已失败的渠道ID，用于重试时排除
+	failedChannelIds := []int{channelId}
+
+	// 获取客户端传递的 X-Response-ID（用于 Claude 缓存定向）
+	claudeResponseID := c.GetHeader("X-Response-ID")
+
 	group := c.GetString("group")
 	retryTimes := config.RetryTimes
 	if !shouldRetry(c, relayError.StatusCode, relayError.Error.Message) {
@@ -2663,16 +2668,11 @@ func RelayResponse(c *gin.Context) {
 		retryTimes = 0
 	}
 	for i := retryTimes; i > 0; i-- {
-		skipPriorityLevels := retryTimes - i
-		channel, err := dbmodel.CacheGetRandomSatisfiedChannel(group, originalModel, skipPriorityLevels)
+		// 使用排除已失败渠道的方式选择新渠道，始终选择最高优先级的可用渠道
+		channel, err := dbmodel.CacheGetRandomSatisfiedChannel(group, originalModel, 0, claudeResponseID, failedChannelIds)
 		if err != nil {
-			logger.Errorf(ctx, "CacheGetRandomSatisfiedChannel failed: %v", err)
+			logger.Errorf(ctx, "CacheGetRandomSatisfiedChannel failed: %v (excludedChannels: %v)", err, failedChannelIds)
 			break
-		}
-
-		// 跳过上次失败的渠道
-		if channel.Id == lastFailedChannelId {
-			continue
 		}
 
 		// 获取重试原因 - 直接使用原始错误消息
@@ -2719,9 +2719,11 @@ func RelayResponse(c *gin.Context) {
 		currentAttempt := retryTimes - i + 1
 
 		channelId = c.GetInt("channel_id")
-		lastFailedChannelId = channelId
 		channelName := c.GetString("channel_name")
 		keyIndex := c.GetInt("key_index")
+
+		// 记录失败的渠道ID，下次重试时排除
+		failedChannelIds = append(failedChannelIds, channelId)
 
 		// 记录本次重试失败的日志（耗时为累计耗时，同步记录保证顺序）
 		recordRetryFailureLog(ctx, userId, channel.Id, originalModel, tokenName, requestID, currentAttempt, cumulativeDuration, relayError.Error.Message, channel.Name, channelHistory)

--- a/relay/cache/claude.go
+++ b/relay/cache/claude.go
@@ -1,0 +1,116 @@
+package cache
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/songquanpeng/one-api/common"
+	"github.com/songquanpeng/one-api/common/logger"
+	dbmodel "github.com/songquanpeng/one-api/model"
+	"github.com/songquanpeng/one-api/relay/channel/anthropic"
+)
+
+// HandleClaudeCache 处理 Claude 缓存信息并记录到 Redis
+// responseID: Claude 响应 ID
+// usage: Claude Usage 信息
+// c: gin context
+func HandleClaudeCache(c *gin.Context, responseID string, usage *anthropic.Usage) {
+	channelId := strconv.Itoa(c.GetInt("channel_id"))
+
+	// 调试日志：函数入口
+	logger.SysLog(fmt.Sprintf("[Claude Cache Debug] 进入handleClaudeCache - ResponseID: %s, ChannelID: %s", responseID, channelId))
+
+	if usage == nil {
+		logger.SysLog(fmt.Sprintf("[Claude Cache Debug] Usage为空，跳过缓存处理 - ResponseID: %s", responseID))
+		return
+	}
+
+	// 调试日志：打印完整的 usage 信息
+	logger.SysLog(fmt.Sprintf("[Claude Cache Debug] Usage详情 - ResponseID: %s, InputTokens: %d, OutputTokens: %d, CacheReadInputTokens: %d",
+		responseID, usage.InputTokens, usage.OutputTokens, usage.CacheReadInputTokens))
+
+	if usage.CacheCreation != nil {
+		logger.SysLog(fmt.Sprintf("[Claude Cache Debug] CacheCreation存在 - ResponseID: %s, Ephemeral5m: %d, Ephemeral1h: %d",
+			responseID, usage.CacheCreation.Ephemeral5mInputTokens, usage.CacheCreation.Ephemeral1hInputTokens))
+	} else {
+		logger.SysLog(fmt.Sprintf("[Claude Cache Debug] CacheCreation为空 - ResponseID: %s", responseID))
+	}
+
+	cacheInfo := make(map[string]interface{})
+	expireTime := int64(5) // 默认5分钟
+	shouldCache := false
+
+	// 根据缓存类型设置过期时间
+	if usage.CacheCreation != nil {
+		if usage.CacheCreation.Ephemeral5mInputTokens > 0 {
+			cacheInfo["cache_5m_tokens"] = usage.CacheCreation.Ephemeral5mInputTokens
+			expireTime = 5
+			shouldCache = true
+			logger.SysLog(fmt.Sprintf("[Claude Cache Debug] 检测到5分钟缓存创建 - ResponseID: %s, Tokens: %d",
+				responseID, usage.CacheCreation.Ephemeral5mInputTokens))
+		}
+		if usage.CacheCreation.Ephemeral1hInputTokens > 0 {
+			cacheInfo["cache_1h_tokens"] = usage.CacheCreation.Ephemeral1hInputTokens
+			expireTime = 60
+			shouldCache = true
+			logger.SysLog(fmt.Sprintf("[Claude Cache Debug] 检测到1小时缓存创建 - ResponseID: %s, Tokens: %d",
+				responseID, usage.CacheCreation.Ephemeral1hInputTokens))
+		}
+	}
+
+	// 检查缓存读取情况
+	if usage.CacheReadInputTokens > 0 {
+		cacheInfo["cache_read_tokens"] = usage.CacheReadInputTokens
+		shouldCache = true
+		logger.SysLog(fmt.Sprintf("[Claude Cache Debug] 检测到缓存读取 - ResponseID: %s, ReadTokens: %d",
+			responseID, usage.CacheReadInputTokens))
+
+		// 读取上次的缓存时长
+		oldResponseID := c.GetHeader("X-Response-ID")
+		logger.SysLog(fmt.Sprintf("[Claude Cache Debug] 尝试读取上次缓存时长 - NewResponseID: %s, OldResponseID: %s",
+			responseID, oldResponseID))
+
+		if oldResponseID != "" {
+			cacheKey := fmt.Sprintf(common.CacheClaudeLength, oldResponseID)
+			logger.SysLog(fmt.Sprintf("[Claude Cache Debug] Redis Key: %s", cacheKey))
+
+			cacheLength, err := common.RedisGet(cacheKey)
+			if err != nil {
+				logger.Error(c.Request.Context(), fmt.Sprintf("[Claude Cache Debug] 读取缓存时长失败 - Key: %s, Error: %s",
+					cacheKey, err.Error()))
+			} else if cacheLength != "" {
+				expireTime1, parseErr := strconv.ParseInt(cacheLength, 10, 64)
+				if parseErr == nil {
+					expireTime = expireTime1
+					logger.SysLog(fmt.Sprintf("[Claude Cache Debug] 成功读取缓存时长 - OldResponseID: %s, ExpireTime: %d分钟",
+						oldResponseID, expireTime))
+				} else {
+					logger.Error(c.Request.Context(), fmt.Sprintf("[Claude Cache Debug] 解析缓存时长失败 - Value: %s, Error: %s",
+						cacheLength, parseErr.Error()))
+				}
+			} else {
+				logger.SysLog(fmt.Sprintf("[Claude Cache Debug] Redis中未找到缓存时长 - Key: %s", cacheKey))
+			}
+		} else {
+			logger.SysLog("[Claude Cache Debug] X-Response-ID header为空，无法读取上次缓存时长")
+		}
+		expireTime = 5
+	}
+
+	// 记录到 Redis
+	if shouldCache {
+		logger.SysLog(fmt.Sprintf("[Claude Cache Debug] 准备写入Redis - ResponseID: %s, ChannelID: %s, ExpireTime: %d分钟",
+			responseID, channelId, expireTime))
+
+		if err := dbmodel.SetClaudeCacheIdToRedis(responseID, channelId, expireTime); err != nil {
+			logger.Error(c.Request.Context(), fmt.Sprintf("[Claude Cache] 写入Redis失败 - ResponseID: %s, Error: %s",
+				responseID, err.Error()))
+		} else {
+			logger.SysLog(fmt.Sprintf("[Claude Cache] 成功写入Redis - RequestID: %s, CacheInfo: %v, ChannelID: %s, Expire: %dm",
+				responseID, cacheInfo, channelId, expireTime))
+		}
+	} else {
+		logger.SysLog(fmt.Sprintf("[Claude Cache Debug] 无需缓存 - ResponseID: %s, 原因: CacheCreation和CacheRead都为0", responseID))
+	}
+}

--- a/relay/channel/aws/claude/main.go
+++ b/relay/channel/aws/claude/main.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/songquanpeng/one-api/relay/controller"
 	"io"
 	"net/http"
 	"reflect"
@@ -23,6 +22,7 @@ import (
 	"github.com/songquanpeng/one-api/common/logger"
 	"github.com/songquanpeng/one-api/relay/channel/anthropic"
 	"github.com/songquanpeng/one-api/relay/channel/aws/utils"
+	"github.com/songquanpeng/one-api/relay/cache"
 	"github.com/songquanpeng/one-api/relay/channel/openai"
 	relaymodel "github.com/songquanpeng/one-api/relay/model"
 	"github.com/songquanpeng/one-api/relay/util"
@@ -466,7 +466,7 @@ func NativeHandler(c *gin.Context, awsCli *bedrockruntime.Client, meta *util.Rel
 	if claudeResponse.Usage != nil {
 		logger.SysLog(fmt.Sprintf("[Claude Cache Debug] aws NativeHandler 准备调用handleClaudeCache - ResponseID: %s, InputTokens: %d, OutputTokens: %d",
 			claudeResponse.Id, claudeResponse.Usage.InputTokens, claudeResponse.Usage.OutputTokens))
-		controller.HandleClaudeCache(c, claudeResponse.Id, claudeResponse.Usage)
+		cache.HandleClaudeCache(c, claudeResponse.Id, claudeResponse.Usage)
 	} else {
 		logger.SysLog(fmt.Sprintf("[Claude Cache Debug] aws NativeHandler Usage为空，跳过缓存处理 - ResponseID: %s", claudeResponse.Id))
 	}
@@ -538,7 +538,7 @@ func NativeStreamHandler(c *gin.Context, awsCli *bedrockruntime.Client, meta *ut
 					// 判断是否创建或读取了缓存，并记录到 redis 中
 					logger.SysLog(fmt.Sprintf("[Claude Cache Debug] aws NativeStreamHandler 准备调用handleClaudeCache(流式) - ResponseID: %s, InputTokens: %d",
 						claudeResp.Message.Id, usage.TotalTokens))
-					controller.HandleClaudeCache(c, claudeResp.Message.Id, claudeResp.Message.Usage)
+					cache.HandleClaudeCache(c, claudeResp.Message.Id, claudeResp.Message.Usage)
 				}
 				if claudeResp.Type == "message_delta" && claudeResp.Usage != nil {
 					usage.CompletionTokens = claudeResp.Usage.OutputTokens

--- a/relay/controller/claude.go
+++ b/relay/controller/claude.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/songquanpeng/one-api/common/config"
 	"github.com/songquanpeng/one-api/common/logger"
 	dbmodel "github.com/songquanpeng/one-api/model"
+	"github.com/songquanpeng/one-api/relay/cache"
 	"github.com/songquanpeng/one-api/relay/channel/anthropic"
 	"github.com/songquanpeng/one-api/relay/channel/openai"
 	"github.com/songquanpeng/one-api/relay/helper"
@@ -24,114 +24,10 @@ import (
 )
 
 // ensureGeminiContentsRole 确保 Gemini 请求体中的 contents 数组中每个元素都有 role 字段
-// Vertex AI API 要求必须指定 role 字段（值为 "user" 或 "model"），而 Gemini 原生 API 可以省略
+// Vertex AI API 要求必须指定 role 字段(值为 "user" 或 "model"),而 Gemini 原生 API 可以省略
 // 此函数用于在发送请求到 Vertex AI 之前自动补全缺失的 role 字段
 
-// HandleClaudeCache 处理 Claude 缓存信息并记录到 Redis
-// responseID: Claude 响应 ID
-// usage: Claude Usage 信息
-// c: gin context
-func HandleClaudeCache(c *gin.Context, responseID string, usage *anthropic.Usage) {
-	channelId := strconv.Itoa(c.GetInt("channel_id"))
-
-	// 调试日志：函数入口
-	logger.SysLog(fmt.Sprintf("[Claude Cache Debug] 进入handleClaudeCache - ResponseID: %s, ChannelID: %s", responseID, channelId))
-
-	if usage == nil {
-		logger.SysLog(fmt.Sprintf("[Claude Cache Debug] Usage为空，跳过缓存处理 - ResponseID: %s", responseID))
-		return
-	}
-
-	// 调试日志：打印完整的 usage 信息
-	logger.SysLog(fmt.Sprintf("[Claude Cache Debug] Usage详情 - ResponseID: %s, InputTokens: %d, OutputTokens: %d, CacheReadInputTokens: %d",
-		responseID, usage.InputTokens, usage.OutputTokens, usage.CacheReadInputTokens))
-
-	if usage.CacheCreation != nil {
-		logger.SysLog(fmt.Sprintf("[Claude Cache Debug] CacheCreation存在 - ResponseID: %s, Ephemeral5m: %d, Ephemeral1h: %d",
-			responseID, usage.CacheCreation.Ephemeral5mInputTokens, usage.CacheCreation.Ephemeral1hInputTokens))
-	} else {
-		logger.SysLog(fmt.Sprintf("[Claude Cache Debug] CacheCreation为空 - ResponseID: %s", responseID))
-	}
-
-	cacheInfo := make(map[string]interface{})
-	expireTime := int64(5) // 默认5分钟
-	shouldCache := false
-
-	// 根据缓存类型设置过期时间
-	if usage.CacheCreation != nil {
-		if usage.CacheCreation.Ephemeral5mInputTokens > 0 {
-			cacheInfo["cache_5m_tokens"] = usage.CacheCreation.Ephemeral5mInputTokens
-			expireTime = 5
-			shouldCache = true
-			logger.SysLog(fmt.Sprintf("[Claude Cache Debug] 检测到5分钟缓存创建 - ResponseID: %s, Tokens: %d",
-				responseID, usage.CacheCreation.Ephemeral5mInputTokens))
-		}
-		if usage.CacheCreation.Ephemeral1hInputTokens > 0 {
-			cacheInfo["cache_1h_tokens"] = usage.CacheCreation.Ephemeral1hInputTokens
-			expireTime = 60
-			shouldCache = true
-			logger.SysLog(fmt.Sprintf("[Claude Cache Debug] 检测到1小时缓存创建 - ResponseID: %s, Tokens: %d",
-				responseID, usage.CacheCreation.Ephemeral1hInputTokens))
-		}
-	}
-
-	// 检查缓存读取情况
-	if usage.CacheReadInputTokens > 0 {
-		cacheInfo["cache_read_tokens"] = usage.CacheReadInputTokens
-		shouldCache = true
-		logger.SysLog(fmt.Sprintf("[Claude Cache Debug] 检测到缓存读取 - ResponseID: %s, ReadTokens: %d",
-			responseID, usage.CacheReadInputTokens))
-
-		// 读取上次的缓存时长
-		oldResponseID := c.GetHeader("X-Response-ID")
-		logger.SysLog(fmt.Sprintf("[Claude Cache Debug] 尝试读取上次缓存时长 - NewResponseID: %s, OldResponseID: %s",
-			responseID, oldResponseID))
-
-		if oldResponseID != "" {
-			cacheKey := fmt.Sprintf(common.CacheClaudeLength, oldResponseID)
-			logger.SysLog(fmt.Sprintf("[Claude Cache Debug] Redis Key: %s", cacheKey))
-
-			cacheLength, err := common.RedisGet(cacheKey)
-			if err != nil {
-				logger.Error(c.Request.Context(), fmt.Sprintf("[Claude Cache Debug] 读取缓存时长失败 - Key: %s, Error: %s",
-					cacheKey, err.Error()))
-			} else if cacheLength != "" {
-				expireTime1, parseErr := strconv.ParseInt(cacheLength, 10, 64)
-				if parseErr == nil {
-					expireTime = expireTime1
-					logger.SysLog(fmt.Sprintf("[Claude Cache Debug] 成功读取缓存时长 - OldResponseID: %s, ExpireTime: %d分钟",
-						oldResponseID, expireTime))
-				} else {
-					logger.Error(c.Request.Context(), fmt.Sprintf("[Claude Cache Debug] 解析缓存时长失败 - Value: %s, Error: %s",
-						cacheLength, parseErr.Error()))
-				}
-			} else {
-				logger.SysLog(fmt.Sprintf("[Claude Cache Debug] Redis中未找到缓存时长 - Key: %s", cacheKey))
-			}
-		} else {
-			logger.SysLog("[Claude Cache Debug] X-Response-ID header为空，无法读取上次缓存时长")
-		}
-		expireTime = 5
-	}
-
-	// 记录到 Redis
-	if shouldCache {
-		logger.SysLog(fmt.Sprintf("[Claude Cache Debug] 准备写入Redis - ResponseID: %s, ChannelID: %s, ExpireTime: %d分钟",
-			responseID, channelId, expireTime))
-
-		if err := dbmodel.SetClaudeCacheIdToRedis(responseID, channelId, expireTime); err != nil {
-			logger.Error(c.Request.Context(), fmt.Sprintf("[Claude Cache] 写入Redis失败 - ResponseID: %s, Error: %s",
-				responseID, err.Error()))
-		} else {
-			logger.SysLog(fmt.Sprintf("[Claude Cache] 成功写入Redis - RequestID: %s, CacheInfo: %v, ChannelID: %s, Expire: %dm",
-				responseID, cacheInfo, channelId, expireTime))
-		}
-	} else {
-		logger.SysLog(fmt.Sprintf("[Claude Cache Debug] 无需缓存 - ResponseID: %s, 原因: CacheCreation和CacheRead都为0", responseID))
-	}
-}
-
-// RelayGeminiNative 处理 Gemini 原生 API 请求
+// RelayClaudeNative 处理 Gemini 原生 API 请求
 func RelayClaudeNative(c *gin.Context) *model.ErrorWithStatusCode {
 	ctx := c.Request.Context()
 	startTime := time.Now()
@@ -557,7 +453,7 @@ func doNativeClaudeResponse(c *gin.Context, resp *http.Response, meta *util.Rela
 	if claudeResponse.Usage != nil {
 		logger.SysLog(fmt.Sprintf("[Claude Cache Debug] 准备调用handleClaudeCache - ResponseID: %s, InputTokens: %d, OutputTokens: %d",
 			claudeResponse.Id, claudeResponse.Usage.InputTokens, claudeResponse.Usage.OutputTokens))
-		HandleClaudeCache(c, claudeResponse.Id, claudeResponse.Usage)
+		cache.HandleClaudeCache(c, claudeResponse.Id, claudeResponse.Usage)
 	} else {
 		logger.SysLog(fmt.Sprintf("[Claude Cache Debug] Usage为空，跳过缓存处理 - ResponseID: %s", claudeResponse.Id))
 	}
@@ -619,7 +515,7 @@ func doNativeClaudeStreamResponse(c *gin.Context, resp *http.Response, meta *uti
 			if lastUsageMetadata != nil {
 				logger.SysLog(fmt.Sprintf("[Claude Cache Debug] 准备调用handleClaudeCache(流式) - ResponseID: %s, InputTokens: %d, OutputTokens: %d",
 					claudeResponse.Message.Id, lastUsageMetadata.InputTokens, lastUsageMetadata.OutputTokens))
-				HandleClaudeCache(c, claudeResponse.Message.Id, lastUsageMetadata)
+				cache.HandleClaudeCache(c, claudeResponse.Message.Id, lastUsageMetadata)
 			} else {
 				logger.SysLog(fmt.Sprintf("[Claude Cache Debug] Usage为空，跳过缓存处理(流式) - ResponseID: %s", claudeResponse.Message.Id))
 			}


### PR DESCRIPTION
1. 修复循环依赖问题
   - 创建独立的 relay/cache 包
   - 将 HandleClaudeCache 从 relay/controller 移到 relay/cache
   - 解除 relay/channel/aws/claude 和 relay/controller 之间的循环依赖

2. 修复 CacheGetRandomSatisfiedChannel 参数不匹配
   - 添加缺失的 responseID 参数（支持 Claude 缓存定向）
   - 添加 excludeChannelIds 参数（排除已失败渠道）

3. 改进重试逻辑
   - 使用 failedChannelIds 列表记录所有失败渠道
   - 避免重复选择已失败的渠道
   - 支持通过 X-Response-ID 进行 Claude 缓存定向

修改的文件：
- relay/cache/claude.go (新建)
- relay/channel/aws/claude/main.go
- relay/controller/claude.go
- controller/relay.go