### PR TITLE
refactor: DoResponse 透传 Kling 原始响应，统一错误处理逻辑

### DIFF
--- a/relay/channel/kling/adaptor.go
+++ b/relay/channel/kling/adaptor.go
@@ -141,16 +141,12 @@ func (a *Adaptor) DoResponse(c *gin.Context, resp *http.Response, meta *util.Rel
 			Error:      model.Error{Message: "解析响应失败: " + unmarshalErr.Error()},
 		}
 	}
-	logger.SysLog(fmt.Sprintf("Kling response: code=%d, task_id=%s, status=%s",
-		klingResp.Code, klingResp.GetTaskID(), klingResp.GetTaskStatus()))
 
-	if klingResp.Code != 0 {
-		return nil, &model.ErrorWithStatusCode{
-			StatusCode: resp.StatusCode,
-			Error:      model.Error{Message: klingResp.Message},
-		}
-	}
+	// 记录日志（不管成功失败）
+	logger.Debug(c, fmt.Sprintf("Kling response: code=%d, task_id=%s, status=%s, message=%s",
+		klingResp.Code, klingResp.GetTaskID(), klingResp.GetTaskStatus(), klingResp.Message))
 
+	// 不管成功失败，都透传原始 Kling 返回数据
 	return &klingResp, nil
 }
 


### PR DESCRIPTION
## 核心改动

### 1. DoResponse 方法简化
- 移除 Code != 0 的错误判断和转换
- 不管成功失败，都返回原始 Kling 响应数据
- 错误判断逻辑上移到调用方处理

### 2. 统一所有接口的错误处理
**同步接口**:
- DoIdentifyFace: 透传原始响应，不扣费
- processSyncTask: 检查 Code 和 Message，透传原始响应，不扣费

**异步接口**:
- processAsyncTask: 检查 Code，透传原始响应
- DoAdvancedLipSync: 检查 Code，透传原始响应

### 3. 设计理念
- DoResponse 职责单一：仅负责读取和解析响应
- 由调用方根据业务逻辑判断 klingResp.Code 是否为 0
- 所有响应都使用 200 状态码 + 原始 JSON 透传给客户端
- 客户端可以看到完整的 Kling 错误信息（code + message）

### 4. 错误处理流程
```
请求 Kling API
    ↓
DoResponse 解析响应
    ↓
调用方检查 klingResp.Code
    ↓
Code != 0 → 标记任务失败 + HTTP 200 + 原始响应（不扣费）
Code == 0 → 处理成功逻辑 + 扣费
    ↓
返回给客户端
```

## 修改文件
- relay/channel/kling/adaptor.go: DoResponse 移除错误转换
- controller/kling_video.go: processAsyncTask 和 processSyncTask 增加错误检查
- relay/controller/kling_video.go: DoIdentifyFace 和 DoAdvancedLipSync 透传原始响应