### PR TITLE
fix: 修复透传查询接口路径丢失 ID 参数的问题

### DIFF
--- a/controller/kling_video.go
+++ b/controller/kling_video.go
@@ -527,8 +527,15 @@ func RelayKlingTransparent(c *gin.Context) {
 		return
 	}
 
-	// 初始化 Adaptor
-	adaptor := &kling.Adaptor{RequestType: requestType}
+	// 提取完整路径（去掉 /kling 前缀）
+	// 例如：/kling/v1/videos/text2video/123 -> /v1/videos/text2video/123
+	fullPath := strings.TrimPrefix(c.Request.URL.Path, "/kling")
+
+	// 初始化 Adaptor（透传模式：使用完整路径）
+	adaptor := &kling.Adaptor{
+		RequestType: requestType,
+		FullPath:    fullPath,
+	}
 	adaptor.Init(meta)
 
 	// 准备请求体（对于 GET 和 DELETE 请求可能为空）

--- a/relay/channel/kling/adaptor.go
+++ b/relay/channel/kling/adaptor.go
@@ -13,7 +13,8 @@ import (
 )
 
 type Adaptor struct {
-	RequestType string // text2video/omni-video/image2video/multi-image2video
+	RequestType  string // text2video/omni-video/image2video/multi-image2video
+	FullPath     string // 透传模式下使用完整路径（包含 ID 等参数）
 }
 
 func (a *Adaptor) Init(meta *util.RelayMeta) {
@@ -24,6 +25,11 @@ func (a *Adaptor) GetRequestURL(meta *util.RelayMeta) (string, error) {
 	baseURL := meta.BaseURL
 	if baseURL == "" {
 		baseURL = "https://api-beijing.klingai.com"
+	}
+
+	// 透传模式：直接使用完整路径
+	if a.FullPath != "" {
+		return baseURL + a.FullPath, nil
 	}
 
 	// 根据请求类型确定路径前缀


### PR DESCRIPTION
## 问题描述
使用通配符路由后，查询单个任务时 ID 参数丢失：
- 用户请求：GET /kling/v1/videos/text2video/842885796897509425
- 实际转发：GET /v1/videos/text2video（丢失 ID）
- 错误结果：返回批量查询结果而不是单个任务

## 根本原因
`GetRequestURL()` 只根据 `requestType` 构建基础路径，不保留 ID 参数：
```go
// 之前的逻辑
return fmt.Sprintf("%s%s/%s", baseURL, pathPrefix, a.RequestType)
// 结果：/v1/videos/text2video（丢失 /842885796897509425）
```

## 解决方案
1. **Adaptor 添加 FullPath 字段**
   - 用于透传模式下保存完整路径（包含 ID 等参数）

2. **GetRequestURL 优先使用 FullPath** ```go if a.FullPath != "" { return baseURL + a.FullPath, nil } ```

3. **RelayKlingTransparent 设置 FullPath** ```go fullPath := strings.TrimPrefix(c.Request.URL.Path, "/kling") adaptor := &kling.Adaptor{ RequestType: requestType,
       FullPath:    fullPath,  // 保留完整路径
   }
   ```

## 请求流程示例
```
用户请求：GET /kling/v1/videos/text2video/842885796897509425
         ↓
RelayKlingTransparent 提取：fullPath = /v1/videos/text2video/842885796897509425
         ↓
GetRequestURL 构建：https://api-beijing.klingai.com/v1/videos/text2video/842885796897509425
         ↓
正确查询单个任务 ✓
```

## 修改文件
- relay/channel/kling/adaptor.go: 添加 FullPath 字段和透传逻辑
- controller/kling_video.go: RelayKlingTransparent 设置 FullPath