### PR TITLE
refactor: 移除虚假的 request_id 生成，直接保存 Kling 回调原始数据

### DIFF
--- a/controller/kling_video.go
+++ b/controller/kling_video.go
@@ -386,24 +386,9 @@ func handleCallback(c *gin.Context, task *kling.TaskWrapper, notification *kling
 		return
 	}
 
-	// 转换回调数据为查询数据格式
-	queryResponse := kling.QueryTaskResponse{
-		Code:      0,
-		Message:   "success",
-		RequestID: fmt.Sprintf("callback-%s", taskID),
-		Data: kling.TaskData{
-			TaskID:        notification.TaskID,
-			TaskStatus:    notification.TaskStatus,
-			TaskStatusMsg: notification.TaskStatusMsg,
-			TaskInfo:      notification.TaskInfo,
-			CreatedAt:     notification.CreatedAt,
-			UpdatedAt:     notification.UpdatedAt,
-			TaskResult:    notification.TaskResult,
-		},
-	}
-
-	queryResponseBytes, _ := json.Marshal(queryResponse)
-	task.SetResult(string(queryResponseBytes))
+	// 直接保存 Kling 回调的原始 JSON（不做转换，不生成虚假的 request_id）
+	notificationBytes, _ := json.Marshal(notification)
+	task.SetResult(string(notificationBytes))
 
 	// 处理成功状态
 	if notification.TaskStatus == kling.TaskStatusSucceed {


### PR DESCRIPTION
问题：
回调处理时将 CallbackNotification 转换成 QueryTaskResponse 格式， 并自己生成了一个虚假的 request_id: "callback-{task_id}"。

这个生成的 request_id 没有任何意义，不是 Kling API 返回的真实数据，
属于过度设计。

解决方案：
直接保存 Kling 回调的原始 JSON 到 result 字段，不做任何格式转换。

Before:
{
  "code": 0,
  "message": "success",
  "request_id": "callback-842897619780804683",  // 虚假生成
  "data": { ... }
}

After:
{
  "task_id": "842897619780804683",
  "task_status": "succeed",
  "task_result": { ... },
  // Kling 原始回调数据
}