### PR TITLE
feat: 添加 Flux API 的 x-key header 认证支持

### DIFF
--- a/middleware/auth.go
+++ b/middleware/auth.go
@@ -99,22 +99,31 @@ func TokenAuth() func(c *gin.Context) {
 			}
 		}
 
-		// Gemini API 从 query 参数或 x-goog-api-key header 中获取 key
-		// 支持 v1beta、v1alpha、v1 等版本路径
-		if strings.HasPrefix(c.Request.URL.Path, "/v1beta/models") ||
-			strings.HasPrefix(c.Request.URL.Path, "/v1beta/openai/models") ||
-			strings.HasPrefix(c.Request.URL.Path, "/v1alpha/models") ||
-			strings.HasPrefix(c.Request.URL.Path, "/v1/models/") {
-			skKey := c.Query("key")
-			if skKey != "" {
-				c.Request.Header.Set("Authorization", "Bearer "+skKey)
-			}
-			// 从 x-goog-api-key header 中获取 key
-			xGoogKey := c.Request.Header.Get("x-goog-api-key")
-			if xGoogKey != "" {
-				c.Request.Header.Set("Authorization", "Bearer "+xGoogKey)
-			}
+	// Gemini API 从 query 参数或 x-goog-api-key header 中获取 key
+	// 支持 v1beta、v1alpha、v1 等版本路径
+	if strings.HasPrefix(c.Request.URL.Path, "/v1beta/models") ||
+		strings.HasPrefix(c.Request.URL.Path, "/v1beta/openai/models") ||
+		strings.HasPrefix(c.Request.URL.Path, "/v1alpha/models") ||
+		strings.HasPrefix(c.Request.URL.Path, "/v1/models/") {
+		skKey := c.Query("key")
+		if skKey != "" {
+			c.Request.Header.Set("Authorization", "Bearer "+skKey)
 		}
+		// 从 x-goog-api-key header 中获取 key
+		xGoogKey := c.Request.Header.Get("x-goog-api-key")
+		if xGoogKey != "" {
+			c.Request.Header.Set("Authorization", "Bearer "+xGoogKey)
+		}
+	}
+
+	// Flux API 从 x-key header 中获取 key
+	// 支持 /flux/ 路径
+	if strings.HasPrefix(c.Request.URL.Path, "/flux/") {
+		xKey := c.Request.Header.Get("x-key")
+		if xKey != "" {
+			c.Request.Header.Set("Authorization", "Bearer "+xKey)
+		}
+	}
 		key := c.Request.Header.Get("Authorization")
 		parts := make([]string, 0)
 		key = strings.TrimPrefix(key, "Bearer ")

--- a/relay/channel/flux/adaptor.go
+++ b/relay/channel/flux/adaptor.go
@@ -67,9 +67,17 @@ func (a *Adaptor) GetRequestURL(meta *util.RelayMeta) (string, error) {
 }
 
 // SetupRequestHeader 设置请求头
+// 接收客户端请求时兼容两种认证方式：
+// 1. Authorization: Bearer <token> 或 Authorization: <token>
+// 2. x-key: <api-key>
+// 但向 Flux API 发送时统一使用官方的 x-key header
 func (a *Adaptor) SetupRequestHeader(c *gin.Context, req *http.Request, meta *util.RelayMeta) error {
 	req.Header.Set("Content-Type", "application/json")
+	
+	// 使用渠道配置的 APIKey（meta.APIKey 已经在中间件中提取并验证）
+	// 统一使用官方的 x-key header 格式
 	req.Header.Set("x-key", meta.APIKey)
+	
 	return nil
 }
 
@@ -457,7 +465,7 @@ func (a *Adaptor) QueryResult(c *gin.Context, taskID string, baseURL string, api
 		return http.StatusInternalServerError, nil, fmt.Errorf("创建请求失败: %w", err)
 	}
 
-	// 3. 设置请求头
+	// 3. 设置请求头 - 使用官方的 x-key header
 	req.Header.Set("x-key", apiKey)
 
 	// 4. 发送请求


### PR DESCRIPTION
主要变更：
- middleware/auth.go: 支持 Flux API 从 x-key header 获取认证信息
- relay/channel/flux/adaptor.go: 统一使用官方的 x-key header 格式发送请求

认证方式兼容：
- 客户端支持 Authorization: Bearer <token> 或 x-key: <api-key>
- 向 Flux API 发送时统一使用 x-key: <api-key>