### PR TITLE
fix(channel): 禁用/启用渠道后立即刷新内存缓存

### DIFF
--- a/model/channel.go
+++ b/model/channel.go
@@ -703,6 +703,7 @@ func UpdateChannelStatusById(id int, status int) error {
 		statusText = fmt.Sprintf("状态%d", status)
 	}
 
+	InitChannelCache()
 	logger.SysLog(fmt.Sprintf("Successfully updated channel %d status to %s, affected %d abilities", id, statusText, abilityResult.RowsAffected))
 	return nil
 }


### PR DESCRIPTION
UpdateChannelStatusById 提交事务后调用 InitChannelCache()， 使渠道状态变更立即生效，无需等待 SYNC_FREQUENCY 定时同步。