### PR TITLE
fix: 修复非流式 Claude 响应中 Usage 为 nil 时的 panic

### DIFF
--- a/relay/controller/claude.go
+++ b/relay/controller/claude.go
@@ -501,7 +501,7 @@ func doNativeClaudeResponse(c *gin.Context, resp *http.Response, meta *util.Rela
 	if unmarshalErr := json.Unmarshal(responseBody, &claudeResponse); unmarshalErr != nil {
 		return nil, openai.ErrorWrapper(unmarshalErr, "unmarshal_response_failed", http.StatusInternalServerError)
 	}
-	if claudeResponse.Usage.ServerToolUse != nil && claudeResponse.Usage.ServerToolUse.WebSearchRequests > 0 {
+	if claudeResponse.Usage != nil && claudeResponse.Usage.ServerToolUse != nil && claudeResponse.Usage.ServerToolUse.WebSearchRequests > 0 {
 		c.Set("claude_web_search_requests", claudeResponse.Usage.ServerToolUse.WebSearchRequests)
 	}
 


### PR DESCRIPTION
当 Claude 返回 usage 字段为 null 的响应时，直接访问
claudeResponse.Usage.ServerToolUse 导致 nil pointer dereference。 在访问前增加 Usage != nil 判断，与同函数其他位置保持一致。