### PR TITLE
fix(gemini): 修正 reasoning_effort 到 thinking_level 的映射

### DIFF
--- a/relay/channel/gemini/main.go
+++ b/relay/channel/gemini/main.go
@@ -185,21 +185,23 @@ func ConvertRequest(textRequest model.GeneralOpenAIRequest) (*ChatRequest, error
 	}
 
 	// Handle reasoning_effort -> thinking_level mapping for Gemini 3
-	// Reference: https://ai.google.dev/gemini-api/docs/gemini-3?hl=zh_cn#thinking_level
-	// Gemini 3 thinking_level values: "none", "minimal", "low", "medium", "high"
-	// Note: OpenAI "medium" maps to Gemini "high" per Google's documentation
+	// Reference: https://ai.google.dev/gemini-api/docs/gemini-3#thinking_level
+	// Gemini 3 thinking_level valid values: "minimal", "low", "medium", "high" (NO "none")
+	// "minimal" matches the "no thinking" setting; Pro models do NOT support "minimal" (lowest is "low")
 	if textRequest.ReasoningEffort != "" {
 		thinkingLevel := ""
+		isPro := strings.Contains(strings.ToLower(textRequest.Model), "-pro")
 		switch strings.ToLower(textRequest.ReasoningEffort) {
-		case "none":
-			thinkingLevel = "none"
-		case "minimal":
-			thinkingLevel = "minimal"
+		case "none", "minimal":
+			if isPro {
+				thinkingLevel = "low"
+			} else {
+				thinkingLevel = "minimal"
+			}
 		case "low":
 			thinkingLevel = "low"
 		case "medium":
-			// Per Gemini docs: reasoning_effort medium maps to thinking_level high
-			thinkingLevel = "high"
+			thinkingLevel = "medium"
 		case "high":
 			thinkingLevel = "high"
 		}


### PR DESCRIPTION
Gemini 3 的 thinking_level 合法值仅为 minimal/low/medium/high，不存在 "none"。原代码把 reasoning_effort=none 映射成 thinking_level=none 会触发 400 INVALID_ARGUMENT；medium 错误映射到 high 也偏离了官方语义。

- none/minimal → minimal（Pro 模型不支持 minimal，降级为 low）
- medium → medium（去除错误的 → high 映射）